### PR TITLE
Add SSM parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ This means that before you use this terraform module, you will need to:
 * [Terraform module for AWS Lambda function using AWS Landing Zone reader](https://github.com/MitocGroup/terraform-aws-landing-zone/tree/master/examples/example_landing_zone_reader)
 
 
+## Managing Secrets
+
+Use the optional `ssm_parameters` variable to create AWS Systems Manager
+parameters alongside your landing zone. Each map key represents the
+parameter name while the value defines its attributes.
+
+Example `terraform.tfvars`:
+
+```hcl
+ssm_parameters = {
+  "/myapp/db_password" = {
+    value       = "supersecret"
+    type        = "SecureString"
+    description = "Database password"
+  }
+}
+```
+
+
 ## What Components Are Available
 AWS Landing Zone solution is defined by the following strategy:
 1. [Multi-Account Structure](#multi-account-structure)

--- a/main.tf
+++ b/main.tf
@@ -6,3 +6,9 @@ module "landing_zone" {
   terraform_backend       = var.terraform_backend
   terraform_config        = var.terraform_config
 }
+
+module "ssm_parameters" {
+  source                 = "./modules/ssm_parameters"
+  landing_zone_providers = var.landing_zone_providers
+  ssm_parameters         = var.ssm_parameters
+}

--- a/modules/ssm_parameters/main.tf
+++ b/modules/ssm_parameters/main.tf
@@ -1,0 +1,12 @@
+resource "aws_ssm_parameter" "this" {
+  for_each = var.ssm_parameters
+
+  name        = each.key
+  value       = lookup(each.value, "value", "")
+  type        = lookup(each.value, "type", "SecureString")
+  description = lookup(each.value, "description", null)
+  key_id      = lookup(each.value, "key_id", null)
+  tier        = lookup(each.value, "tier", null)
+  overwrite   = lookup(each.value, "overwrite", "false") == "true" ? true : false
+  allowed_pattern = lookup(each.value, "allowed_pattern", null)
+}

--- a/modules/ssm_parameters/outputs.tf
+++ b/modules/ssm_parameters/outputs.tf
@@ -1,0 +1,9 @@
+output "parameter_arns" {
+  value       = { for k, p in aws_ssm_parameter.this : k => p.arn }
+  description = "ARNs of created SSM parameters."
+}
+
+output "parameter_names" {
+  value       = [for p in aws_ssm_parameter.this : p.name]
+  description = "Names of created SSM parameters."
+}

--- a/modules/ssm_parameters/provider.tf
+++ b/modules/ssm_parameters/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region              = var.landing_zone_providers["default"]["region"]
+  allowed_account_ids = [var.landing_zone_providers["default"]["account_id"]]
+}

--- a/modules/ssm_parameters/variables.tf
+++ b/modules/ssm_parameters/variables.tf
@@ -1,0 +1,9 @@
+variable "landing_zone_providers" {
+  type        = map(map(string))
+  description = "The list of AWS providers."
+}
+
+variable "ssm_parameters" {
+  type        = map(map(string))
+  description = "Map of SSM parameter configurations keyed by name."
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -582,3 +582,13 @@ output "landing_zone_guardduty_member_relationship_statuses" {
   value       = lookup(module.landing_zone.landing_zone, "landing_zone_guardduty_member_relationship_statuses", "Is not set!")
   description = "The statuses of the relationship between the member account and its master account."
 }
+
+output "ssm_parameter_arns" {
+  value       = module.ssm_parameters.parameter_arns
+  description = "ARNs of created SSM parameters."
+}
+
+output "ssm_parameter_names" {
+  value       = module.ssm_parameters.parameter_names
+  description = "Names of created SSM parameters."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,3 +22,10 @@ variable "terraform_config" {
   default     = true
   description = "The command that will be generate the `terraform` config file."
 }
+
+variable "ssm_parameters" {
+  type        = map(map(string))
+  description = "Map of SSM parameter configurations keyed by parameter name."
+  default     = {}
+}
+


### PR DESCRIPTION
## Summary
- create new module `ssm_parameters` for provisioning SSM parameters
- expose `ssm_parameters` variable
- wire module in `main.tf`
- output created parameter names and ARNs
- document secret management with tfvars example

## Testing
- `terraform fmt -recursive` *(fails: command not found)*