### PR TITLE
Add network topology doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RELATED: [terraform module `landing_zone_reader`](https://github.com/MitocGroup/
 > NOTE: Current implementation is fully compatible with terraform v0.12+.
 Switch to branch `terraform_v0.11` if you still using terraform v0.11.x and below.
 
-Quick Links: [How Does This Module Work](#how-does-this-module-work) | [What Components Are Available](#what-components-are-available) | [Why to Use This Solution](#why-to-use-this-solution)
+Quick Links: [How Does This Module Work](#how-does-this-module-work) | [What Components Are Available](#what-components-are-available) | [Why to Use This Solution](#why-to-use-this-solution) | [Network Service Topology](docs/network_service_topology.md)
 
 
 ## How Does This Module Work

--- a/docs/network_service_topology.md
+++ b/docs/network_service_topology.md
@@ -1,0 +1,27 @@
+# Network Service Topology
+
+This document describes the high‑level network structure and supporting services that the AWS Landing Zone module deploys. Each diagram below highlights a core part of the landing zone and the roles of its components.
+
+## Multi‑Account Architecture
+
+![AWS Landing Zone Multi-Account Architecture](aws-landing-zone-architecture.png)
+
+The foundation of the landing zone is a multi-account setup. Separate accounts provide logical isolation for security, logging, shared services and application workloads. This structure allows centralized governance while enabling teams to operate independently in their designated accounts.
+
+## Account Vending Machine
+
+![AWS Landing Zone Account Vending Machine Architecture](aws-landing-zone-account-vending-machine.png)
+
+The Account Vending Machine (AVM) automates creation of new AWS accounts. It applies a predefined networking baseline, places the account in the correct organizational unit and configures logging so that new accounts integrate seamlessly with the existing landing zone environment.
+
+## User Access and Identity Management
+
+![AWS Landing Zone User Access and Identity Management Architecture](aws-landing-zone-user-access.png)
+
+User access is managed through centralized identity services. Cross-account roles and single sign-on simplify authentication to new accounts while enforcing least‑privilege permissions. Directory services can also be integrated for organizations that require it.
+
+## Monitoring and Notifications
+
+![AWS Landing Zone Monitoring and Notifications Architecture](aws-landing-zone-notifications.png)
+
+Monitoring components collect metrics and audit logs across all accounts. CloudWatch alarms and events notify administrators of important changes such as security group updates, root logins or policy changes.


### PR DESCRIPTION
## Summary
- document network topology used in AWS Landing Zone
- link the new doc from the README

## Testing
- `npm test` *(fails: Missing script: "test")*