### PR TITLE
Add new EKS and ECR modules

### DIFF
--- a/examples/example_eks_ecr/README.md
+++ b/examples/example_eks_ecr/README.md
@@ -1,0 +1,4 @@
+# example_eks_ecr
+
+This example shows how to deploy the `eks` and `ecr` modules for different environments.
+Set the `environment` variable to `dev`, `stage`, or `prod` to get sensible defaults for each environment.

--- a/examples/example_eks_ecr/main.tf
+++ b/examples/example_eks_ecr/main.tf
@@ -1,0 +1,39 @@
+locals {
+  eks_subnet_ids = {
+    dev   = ["subnet-12345678", "subnet-23456789"]
+    stage = ["subnet-34567890", "subnet-45678901"]
+    prod  = ["subnet-56789012", "subnet-67890123"]
+  }
+}
+
+module "eks" {
+  source                 = "../../modules/eks"
+  landing_zone_providers = {
+    default = {
+      account_id = "123456789012"
+      region     = "us-east-1"
+    }
+  }
+  cluster_name = {
+    dev   = "dev-eks"
+    stage = "stage-eks"
+    prod  = "prod-eks"
+  }[var.environment]
+  subnet_ids   = local.eks_subnet_ids[var.environment]
+  environment  = var.environment
+}
+
+module "ecr" {
+  source                 = "../../modules/ecr"
+  landing_zone_providers = {
+    default = {
+      account_id = "123456789012"
+      region     = "us-east-1"
+    }
+  }
+  repository_name  = {
+    dev   = "dev-repo"
+    stage = "stage-repo"
+    prod  = "prod-repo"
+  }[var.environment]
+}

--- a/examples/example_eks_ecr/variables.tf
+++ b/examples/example_eks_ecr/variables.tf
@@ -1,0 +1,5 @@
+variable "environment" {
+  type        = string
+  description = "Deployment environment (dev, stage, prod)."
+  default     = "dev"
+}

--- a/main.tf
+++ b/main.tf
@@ -12,3 +12,20 @@ module "ssm_parameters" {
   landing_zone_providers = var.landing_zone_providers
   ssm_parameters         = var.ssm_parameters
 }
+
+module "eks" {
+  source                 = "./modules/eks"
+  count                  = var.eks_cluster_name[var.environment] == "" ? 0 : 1
+  landing_zone_providers = var.landing_zone_providers
+  cluster_name           = var.eks_cluster_name[var.environment]
+  subnet_ids             = var.eks_subnet_ids[var.environment]
+  environment            = var.environment
+}
+
+module "ecr" {
+  source                 = "./modules/ecr"
+  count                  = var.ecr_repository_name[var.environment] == "" ? 0 : 1
+  landing_zone_providers = var.landing_zone_providers
+  repository_name        = var.ecr_repository_name[var.environment]
+  lifecycle_policy       = var.ecr_lifecycle_policy
+}

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,0 +1,14 @@
+resource "aws_ecr_repository" "this" {
+  name                 = var.repository_name
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  count      = var.lifecycle_policy == "" ? 0 : 1
+  repository = aws_ecr_repository.this.name
+  policy     = var.lifecycle_policy
+}

--- a/modules/ecr/outputs.tf
+++ b/modules/ecr/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_url" {
+  value       = aws_ecr_repository.this.repository_url
+  description = "URL of the ECR repository."
+}
+
+output "repository_arn" {
+  value       = aws_ecr_repository.this.arn
+  description = "ARN of the ECR repository."
+}

--- a/modules/ecr/provider.tf
+++ b/modules/ecr/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region              = var.landing_zone_providers["default"]["region"]
+  allowed_account_ids = [var.landing_zone_providers["default"]["account_id"]]
+}

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,0 +1,15 @@
+variable "landing_zone_providers" {
+  type        = map(map(string))
+  description = "The list of AWS providers."
+}
+
+variable "repository_name" {
+  type        = string
+  description = "Name of the ECR repository."
+}
+
+variable "lifecycle_policy" {
+  type        = string
+  description = "JSON lifecycle policy for the repository."
+  default     = ""
+}

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -1,0 +1,78 @@
+resource "aws_iam_role" "cluster" {
+  name = "${var.cluster_name}-cluster-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = {
+        Service = "eks.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {
+  role       = aws_iam_role.cluster.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSServicePolicy" {
+  role       = aws_iam_role.cluster.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+}
+
+resource "aws_iam_role" "node" {
+  name = "${var.cluster_name}-node-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKSWorkerNodePolicy" {
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEC2ContainerRegistryReadOnly" {
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKS_CNI_Policy" {
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_eks_cluster" "this" {
+  name     = var.cluster_name
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    subnet_ids = var.subnet_ids
+  }
+}
+
+resource "aws_eks_node_group" "this" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_group_name = "${var.cluster_name}-ng"
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = var.subnet_ids
+  instance_types  = ["m5.2xlarge"]
+  disk_size       = 3072
+
+  scaling_config {
+    desired_size = 3
+    max_size     = 3
+    min_size     = 3
+  }
+}

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -1,0 +1,14 @@
+output "cluster_name" {
+  value       = aws_eks_cluster.this.name
+  description = "Name of the EKS cluster."
+}
+
+output "cluster_endpoint" {
+  value       = aws_eks_cluster.this.endpoint
+  description = "API endpoint of the EKS cluster."
+}
+
+output "node_group_arn" {
+  value       = aws_eks_node_group.this.arn
+  description = "ARN of the node group."
+}

--- a/modules/eks/provider.tf
+++ b/modules/eks/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region              = var.landing_zone_providers["default"]["region"]
+  allowed_account_ids = [var.landing_zone_providers["default"]["account_id"]]
+}

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -1,0 +1,20 @@
+variable "landing_zone_providers" {
+  type        = map(map(string))
+  description = "The list of AWS providers."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Name of the EKS cluster."
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Subnet IDs for the EKS cluster nodes."
+}
+
+variable "environment" {
+  type        = string
+  description = "Deployment environment name."
+  default     = "dev"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -592,3 +592,28 @@ output "ssm_parameter_names" {
   value       = module.ssm_parameters.parameter_names
   description = "Names of created SSM parameters."
 }
+
+output "eks_cluster_name" {
+  value       = try(module.eks[0].cluster_name, null)
+  description = "Name of the EKS cluster."
+}
+
+output "eks_cluster_endpoint" {
+  value       = try(module.eks[0].cluster_endpoint, null)
+  description = "Endpoint of the EKS cluster."
+}
+
+output "eks_node_group_arn" {
+  value       = try(module.eks[0].node_group_arn, null)
+  description = "ARN of the EKS node group."
+}
+
+output "ecr_repository_url" {
+  value       = try(module.ecr[0].repository_url, null)
+  description = "URL of the ECR repository."
+}
+
+output "ecr_repository_arn" {
+  value       = try(module.ecr[0].repository_arn, null)
+  description = "ARN of the ECR repository."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -29,3 +29,45 @@ variable "ssm_parameters" {
   default     = {}
 }
 
+
+variable "environment" {
+  type        = string
+  description = "Deployment environment (dev, stage, prod)."
+  default     = "dev"
+}
+
+variable "eks_cluster_name" {
+  type        = map(string)
+  description = "EKS cluster name per environment. Empty name disables EKS module."
+  default = {
+    dev   = "dev-eks"
+    stage = "stage-eks"
+    prod  = "prod-eks"
+  }
+}
+
+variable "eks_subnet_ids" {
+  type        = map(list(string))
+  description = "Subnet IDs for the EKS cluster nodes per environment."
+  default = {
+    dev   = []
+    stage = []
+    prod  = []
+  }
+}
+
+variable "ecr_repository_name" {
+  type        = map(string)
+  description = "ECR repository name per environment. Empty name disables ECR module."
+  default = {
+    dev   = "dev-repo"
+    stage = "stage-repo"
+    prod  = "prod-repo"
+  }
+}
+
+variable "ecr_lifecycle_policy" {
+  type        = string
+  description = "Optional JSON lifecycle policy for ECR repository."
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- add EKS module to provision an EKS cluster and node group
- add ECR module for container repositories
- expose new module outputs in root
- update root variables and module calls
- provide example showing dev, stage and prod usage

## Testing
- `terraform fmt -recursive modules/eks modules/ecr examples/example_eks_ecr main.tf variables.tf outputs.tf` *(fails: `terraform: command not found`)*